### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/bird.yml
+++ b/.github/workflows/bird.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/bird:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/cgit.yml
+++ b/.github/workflows/cgit.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/cgit:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/openvpn:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/rclone-syncer.yml
+++ b/.github/workflows/rclone-syncer.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/rclone-syncer:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/sfrs.yml
+++ b/.github/workflows/sfrs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/sfrs:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/speedtest-cli-arm32v7.yml
+++ b/.github/workflows/speedtest-cli-arm32v7.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/speedtest-cli:arm32v7
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/speedtest-cli.yml
+++ b/.github/workflows/speedtest-cli.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/speedtest-cli:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/streamlink-bilibili.yml
+++ b/.github/workflows/streamlink-bilibili.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/streamlink-bilibili:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tinc.yml
+++ b/.github/workflows/tinc.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/tinc:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/toshl2influxdb.yml
+++ b/.github/workflows/toshl2influxdb.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/toshl2influxdb:latest
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/zerotier-one.yml
+++ b/.github/workflows/zerotier-one.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.3
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: imlonghao/zerotier-one:latest
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore